### PR TITLE
Build debug refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,27 @@
-FROM alpine:3.4
+FROM golang:1.9 as BUILD
 
-ENV GOPATH /go
-ENV PATH $PATH:/go/bin
+ENV DELVE_VERSION=1.0.0-rc.1
 
-RUN echo "@community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-
-RUN apk update && apk upgrade && \
-    mkdir -p /go/bin && \
-    apk -v add git make bash go@community musl-dev curl && \
-    go version
+RUN go get -d github.com/derekparker/delve/cmd/dlv
+RUN cd /go/src/github.com/derekparker/delve && git checkout v$DELVE_VERSION
+RUN go install github.com/derekparker/delve/cmd/dlv
 
 COPY ./ /go/src/github.com/Axway/elasticsearch-docker-beat
+RUN cd  /go/src/github.com/Axway/elasticsearch-docker-beat && \
+    make
 
-RUN cd $GOPATH/src/github.com/Axway/elasticsearch-docker-beat && \
-    make && \
-    echo elasticsearch-docker-beat built && \
-    mkdir -p /etc/dbeat && \
-    mkdir -p /etc/beatconf && \
-    cp $GOPATH/src/github.com/Axway/elasticsearch-docker-beat/elasticsearch-docker-beat /etc/dbeat/dbeat && \
-    cp $GOPATH/src/github.com/Axway/elasticsearch-docker-beat/dbeat-confimage.yml /etc/beatconf/dbeat.yml && \
-    cp $GOPATH/src/github.com/Axway/elasticsearch-docker-beat/*.json /etc/dbeat && \
-    chmod +x /etc/dbeat/dbeat && \
-    cd $GOPATH && \
-    rm -rf $GOPATH/src && \
-    rm -rf /root/.glide
+FROM frolvlad/alpine-glibc
+
+COPY --from=BUILD /go/bin/dlv /usr/local/bin
+COPY --from=BUILD /go/src/github.com/Axway/elasticsearch-docker-beat/elasticsearch-docker-beat /etc/dbeat/dbeat
+COPY ./dbeat-confimage.yml /etc/beatconf/dbeat.yml
+COPY ./*.json /etc/dbeat/
 
 WORKDIR /etc/dbeat
 
 HEALTHCHECK --interval=10s --timeout=15s --retries=12 CMD curl localhost:3000/health
 
 CMD ["/etc/dbeat/dbeat", "-e", "-c", "/etc/beatconf/dbeat.yml"]
+
+# For remote debugging purposes
+# CMD ["/usr/local/bin/dlv", "--listen=:2345", "--headless=true", "--api-version=2", "exec", "/etc/dbeat/dbeat", "--", "-e", "-c", "/etc/beatconf/dbeat.yml", "-strict.perms=false"]

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ create-image:
 	rm -f elasticsearch-docker-beat
 	docker build -t axway/elasticsearch-docker-beat:latest .
 
+.PHONY: push-image
+push-image: create-image
+	docker save axway/elasticsearch-docker-beat -o dbeat.dimg
+	docker-machine scp dbeat.dimg default:/tmp/
+	docker-machine ssh default docker load -i /tmp/dbeat.dimg
+	rm dbeat.dimg
+	docker-machine ssh default rm /tmp/dbeat.dimg
+
 .PHONY: create-image-test
 create-image-test:
 	rm -f elasticsearch-docker-beat


### PR DESCRIPTION
- Update Dockerfile to split build and runtime in different base images 
- Add dlv (debugger for go). To be popped in a child image in the future.
- Add make target to push local image into docker-machine's default VM