### PR TITLE
Removing -e by default

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,4 +4,4 @@ echo starting conffile updater
 ./updater
 cat /etc/beatconf/dbeat.yml
 echo starting dbeat
-./dbeat -e -c /etc/beatconf/dbeat.yml $@
+./dbeat -c /etc/beatconf/dbeat.yml $@


### PR DESCRIPTION
Removing -e by default, it can still be added when launching by passing as argument to start.sh