### PR TITLE
Service mapping using container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# elasticsearch-docker-beat: latest
+# elasticsearch-docker-beat: 0.0.3
 
 Welcome to elasticsearch-docker-beat
 

--- a/beater/container.go
+++ b/beater/container.go
@@ -171,17 +171,27 @@ func (a *dbeat) addContainer(ID string) {
 			data.name = strings.Replace(data.name, "/", "", 1)
 			data.name = strings.TrimSpace(data.name)
 			labels := inspect.Config.Labels
-			//data.serviceName = a.getMapValue(labels, "com.docker.swarm.service.name")
-			data.serviceName = strings.TrimPrefix(labels["com.docker.swarm.service.name"], labels["com.docker.stack.namespace"]+"_")
-			if data.serviceName == "" {
-				data.serviceName = "noService"
-			}
-			data.shortName = fmt.Sprintf("%s_%d", data.serviceName, data.pid)
-			data.serviceID = a.getMapValue(labels, "com.docker.swarm.service.id")
-			data.nodeID = a.getMapValue(labels, "com.docker.swarm.node.id")
-			data.stackName = a.getMapValue(labels, "com.docker.stack.namespace")
-			if data.stackName == "" {
-				data.stackName = "noStack"
+			if a.config.MappingOnContainerName {
+				list := strings.Split(data.name, "_")
+				if len(list) >= 2 {
+					data.stackName = list[0]
+					data.serviceName = list[1]
+				} else {
+					data.serviceName = "noService"
+					data.stackName = "noStack"
+				}
+			} else {
+				data.serviceName = strings.TrimPrefix(labels["com.docker.swarm.service.name"], labels["com.docker.stack.namespace"]+"_")
+				if data.serviceName == "" {
+					data.serviceName = "noService"
+				}
+				data.shortName = fmt.Sprintf("%s_%d", data.serviceName, data.pid)
+				data.serviceID = a.getMapValue(labels, "com.docker.swarm.service.id")
+				data.nodeID = a.getMapValue(labels, "com.docker.swarm.node.id")
+				data.stackName = a.getMapValue(labels, "com.docker.stack.namespace")
+				if data.stackName == "" {
+					data.stackName = "noStack"
+				}
 			}
 			data.hostIP = a.hostIP
 			data.hostname = a.hostname

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	LogsPlainFiltersContainers map[string][]string          `config:"logs_plain_filters_containers"`
 	LogsPlainFiltersServices   map[string][]string          `config:"logs_plain_filters_services"`
 	LogsPlainFiltersStacks     map[string][]string          `config:"logs_plain_filters_stacks"`
+	MappingOnContainerName     bool                         `config:"mappingOnContainerName"`
 }
 
 // MLConfig multiline config struct


### PR DESCRIPTION
Closes #18

When configuration option: `mappingOnContainerName: true` is set, the service and stack mapping are made using the container name as reqquested in the issue #18 

a container name xxxx_yyyy_132123, will have stack = xxxx and service="yyyy" its logs / metrics meta data

