### PR TITLE
Don't fail if beat.yml is not write protected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ARG LDFLAGS="-s -w"
 RUN make LDFLAGS="${LDFLAGS}"
 RUN go build -ldflags "${LDFLAGS}" -o ./updater /go/src/github.com/Axway/elasticsearch-docker-beat/starter/main.go
 
-FROM alpine:3.7
+FROM alpine:3.8
 
-RUN apk update && apk upgrade && apk add curl && rm -rf /var/cache/apk/*
+RUN apk --no-cache add curl
 COPY --from=BUILD /go/src/github.com/Axway/elasticsearch-docker-beat/elasticsearch-docker-beat /etc/dbeat/dbeat
 COPY --from=BUILD /go/src/github.com/Axway/elasticsearch-docker-beat/updater /etc/dbeat/updater
 COPY ./start.sh /etc/dbeat/start.sh

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ fi
 PROGRAM=/etc/dbeat/dbeat
 set -- $PROGRAM "$@"
 cd /etc/dbeat
-echo "Starting conffile updater"
+echo "Starting configuration file updater"
 ./updater || exit 1
 cat /etc/beatconf/dbeat.yml
 echo "Starting dbeat: $@"


### PR DESCRIPTION
- update to Alpine 3.8
- if beat configuration is not writable (because protected, as is the case with K8s ConfigMaps), don't fail, just log a warning